### PR TITLE
Tweak name of section for adopter guidance

### DIFF
--- a/proposals/spec-lifecycle.md
+++ b/proposals/spec-lifecycle.md
@@ -92,7 +92,7 @@ The group encourages experimental implementation and feedback (or "not yet").
 This technology is experimental and **will** change. 
 
 * **Experimentation status**. Whether it is a good time to experiment with the technology (or not).
-* **Known adoptions**. Identify known pilots or experiments, examples of real-world deployments.
+* **Known adopter interest**. Identify known pilots or experiments, examples of real-world deployments or expressions of interests to use the relevant feature.
 * **Patent licensing commitments**. Typically determined by CLA, but will differ if spec was part of a call for final specification commitments.
 
 ### Standardization plan


### PR DESCRIPTION
There are a number of cases where listing all known adoptions wouldn't make sense (e.g., a CSS property being incubated that gains adoption on hundreds of web sites), so proposing a slight rephrasing (not married to the exact wording)